### PR TITLE
Added black box Nav Drawer tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,10 +64,12 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
-    androidTestCompile ('com.android.support.test.espresso:espresso-contrib:2.2'){
-        exclude group: 'com.android.support', module: 'appcompat-v7'
-        exclude group: 'com.android.support', module: 'support-v4'
+    androidTestCompile ('com.android.support.test.espresso:espresso-contrib:2.2.2'){
+        exclude module: 'support-annotations'
+        exclude module: 'support-v4'
+        exclude module: 'support-v13'
         exclude module: 'recyclerview-v7'
+        exclude module: 'design'
     }
 
 }

--- a/app/src/androidTest/java/edu/usc/sunset/team7/www/parkhere/NavigationDrawerTest.java
+++ b/app/src/androidTest/java/edu/usc/sunset/team7/www/parkhere/NavigationDrawerTest.java
@@ -48,15 +48,17 @@ public class NavigationDrawerTest {
                 .findViewById(R.id.drawer_layout);
         ListView listView = (ListView) activityRule.getActivity().findViewById(R.id.left_drawer);
 
-        for (int i = 0; i < 5; i++) {
-            Assert.assertEquals(drawer.isDrawerOpen(listView), false);
+        Assert.assertEquals(drawer.isDrawerOpen(listView), false);
 
+        for (int i = 0; i < 5; i++) {
             DrawerActions.openDrawer(R.id.drawer_layout);
 
             Assert.assertEquals(drawer.isDrawerOpen(listView), true);
 
             onData(anything()).inAdapterView(withId(R.id.left_drawer))
                     .atPosition(i).perform(click());
+
+            Assert.assertEquals(drawer.isDrawerOpen(listView), false);
         }
     }
 }

--- a/app/src/androidTest/java/edu/usc/sunset/team7/www/parkhere/NavigationDrawerUITest.java
+++ b/app/src/androidTest/java/edu/usc/sunset/team7/www/parkhere/NavigationDrawerUITest.java
@@ -1,6 +1,9 @@
 package edu.usc.sunset.team7.www.parkhere;
 
-import android.app.Fragment;
+/**
+ * Created by Justin on 11/7/2016.
+ */
+
 import android.content.Intent;
 import android.support.test.espresso.contrib.DrawerActions;
 import android.support.test.filters.LargeTest;
@@ -18,15 +21,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import edu.usc.sunset.team7.www.parkhere.Activities.HomeActivity;
-import edu.usc.sunset.team7.www.parkhere.Utils.Consts;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Created by Justin on 11/5/2016.
@@ -34,7 +38,7 @@ import static org.hamcrest.Matchers.anything;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
-public class NavigationFragmentTest {
+public class NavigationDrawerUITest {
 
     @Rule
     public ActivityTestRule<HomeActivity> activityRule =
@@ -49,36 +53,20 @@ public class NavigationFragmentTest {
     public void runNavigationDrawerTest(){
         Intent intent = new Intent();
         activityRule.launchActivity(intent);
-        for (int i = 0; i < 5; i++) {
-            String fragment_tag = "";
 
-            onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
+        onView(withId(R.id.left_drawer)).check(matches(not(isDisplayed())));
+
+        for (int i = 0; i < 5; i++) {
+
+            onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
+                    .check(matches(isDisplayed()));
+            onView(withId(R.id.left_drawer)).check(matches(isDisplayed()));
 
             onData(anything()).inAdapterView(withId(R.id.left_drawer))
                     .atPosition(i).perform(click());
 
-            switch(i){
-                case 0:
-                    fragment_tag = Consts.SEARCH_FRAGMENT_TAG;
-                    break;
-                case 1:
-                    fragment_tag = Consts.LISTING_FRAGMENT_TAG;
-                    break;
-                case 2:
-                    fragment_tag = Consts.BOOKING_FRAGMENT_TAG;
-                    break;
-                case 3:
-                    fragment_tag = Consts.BALANCE_FRAGMENT_TAG;
-                    break;
-                case 4:
-                    fragment_tag = Consts.MY_PROFILE_FRAGMENT_TAG;
-                    break;
-            }
-
-            Fragment fragment = activityRule.getActivity().getFragmentManager()
-                    .findFragmentByTag(fragment_tag);
-
-            Assert.assertEquals(true, fragment.isVisible());
+            onView(withId(R.id.left_drawer)).check(matches(not(isDisplayed())));
         }
     }
 }
+

--- a/app/src/androidTest/java/edu/usc/sunset/team7/www/parkhere/NavigationFragmentUITest.java
+++ b/app/src/androidTest/java/edu/usc/sunset/team7/www/parkhere/NavigationFragmentUITest.java
@@ -1,0 +1,103 @@
+package edu.usc.sunset.team7.www.parkhere;
+
+import android.app.Fragment;
+import android.content.Intent;
+import android.support.test.espresso.contrib.DrawerActions;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.widget.DrawerLayout;
+import android.widget.ListView;
+
+import com.google.firebase.auth.FirebaseAuth;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import edu.usc.sunset.team7.www.parkhere.Activities.HomeActivity;
+import edu.usc.sunset.team7.www.parkhere.Utils.Consts;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Created by Justin on 11/5/2016.
+ */
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class NavigationFragmentUITest {
+
+    @Rule
+    public ActivityTestRule<HomeActivity> activityRule =
+            new ActivityTestRule<>(HomeActivity.class, true, false);
+
+    @Before
+    public void initializeActivity() {
+        FirebaseAuth.getInstance().signInWithEmailAndPassword("kunal@me.com", "hello12345");
+    }
+
+    @Test
+    public void runNavigationDrawerTest(){
+        Intent intent = new Intent();
+        activityRule.launchActivity(intent);
+
+        for (int i = 0; i < 5; i++) {
+
+            onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
+
+            onData(anything()).inAdapterView(withId(R.id.left_drawer))
+                    .atPosition(i).perform(click());
+
+            switch(i){
+                case 0:
+                    onView(withId(R.id.fragment_search_layout)).check(matches(isDisplayed()));
+                    onView(withId(R.id.fragment_listing_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_booking_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_balance_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_public_profile_layout)).check(doesNotExist());
+                    break;
+                case 1:
+                    onView(withId(R.id.fragment_listing_layout)).check(matches(isDisplayed()));
+                    onView(withId(R.id.fragment_search_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_booking_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_balance_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_public_profile_layout)).check(doesNotExist());
+                    break;
+                case 2:
+                    onView(withId(R.id.fragment_booking_layout)).check(matches(isDisplayed()));
+                    onView(withId(R.id.fragment_search_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_listing_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_balance_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_public_profile_layout)).check(doesNotExist());
+                    break;
+                case 3:
+                    onView(withId(R.id.fragment_balance_layout)).check(matches(isDisplayed()));
+                    onView(withId(R.id.fragment_search_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_listing_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_booking_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_public_profile_layout)).check(doesNotExist());
+                    break;
+                case 4:
+                    onView(withId(R.id.fragment_public_profile_layout))
+                            .check(matches(isDisplayed()));
+                    onView(withId(R.id.fragment_search_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_listing_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_booking_layout)).check(doesNotExist());
+                    onView(withId(R.id.fragment_balance_layout)).check(doesNotExist());
+                    break;
+            }
+
+        }
+    }
+}

--- a/app/src/main/res/layout/balance_fragment.xml
+++ b/app/src/main/res/layout/balance_fragment.xml
@@ -3,7 +3,8 @@
     android:orientation="vertical"
     android:layout_gravity="center_vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/fragment_balance_layout">
 
     <android.support.v7.widget.AppCompatButton
         android:id="@+id/transfer_button"

--- a/app/src/main/res/layout/booking_fragment.xml
+++ b/app/src/main/res/layout/booking_fragment.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fragment_booking_layout">
 
     <ListView
         android:id="@+id/booking_listview"

--- a/app/src/main/res/layout/listing_fragment.xml
+++ b/app/src/main/res/layout/listing_fragment.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/fragment_listing_layout">
 
     <android.support.v7.widget.AppCompatButton
         android:id="@+id/post_listing_button"

--- a/app/src/main/res/layout/public_profile_fragment.xml
+++ b/app/src/main/res/layout/public_profile_fragment.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/fragment_public_profile_layout">
 
     <LinearLayout
         android:orientation="horizontal"

--- a/app/src/main/res/layout/search_fragment.xml
+++ b/app/src/main/res/layout/search_fragment.xml
@@ -5,7 +5,8 @@
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:id = "@+id/fragment_search_layout">
 
         <TextView
             android:layout_width="match_parent"


### PR DESCRIPTION
Gradle has been updated with a newer version of espresso:espresso-contrib. "opendrawer(int layoutId)" is a deprecated method that has been replaced with "open()". 
XML files have been edited to include an id for the overarching layouts.
Two new black box tests have been added.